### PR TITLE
Fix broken imports in main script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+.pytest_cache/

--- a/Version512_Working.py
+++ b/Version512_Working.py
@@ -1,26 +1,29 @@
 # ---------------------
 # --- Version 5.1.2 ---
 # ---------------------
+import subprocess
+import sys
+
 try:
-    import fpdf
+    from fpdf import FPDF
 except ModuleNotFoundError:
     print("fpdf not found, installing...")
-    !pip install --quiet fpdf2  # Use --quiet to suppress excessive output
-    import fpdf # Import the module after installation
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "--quiet", "fpdf2"])
+    from fpdf import FPDF
 
 try:
     import seaborn
 except ModuleNotFoundError:
     print("seaborn not found, installing...")
-    !pip install seaborn
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "seaborn"])
     import seaborn
 try:
     import IPython
 except ModuleNotFoundError:
     print("IPython not found, installing...")
-    !pip IPython seaborn
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "IPython"])
     import IPython
-%matplotlib inline
+
 from typing import Dict, Callable, Tuple, List
 import numpy as np
 import sympy as sp

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,4 @@
+import py_compile
+
+def test_compiles():
+    py_compile.compile('Version512_Working.py', doraise=True)


### PR DESCRIPTION
## Summary
- remove Jupyter magics from `Version512_Working.py`
- add automatic package installation via subprocess
- include `.gitignore`
- add a small regression test ensuring the file compiles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff54fd838832286d093c75a81038b